### PR TITLE
feat: Add Didit Client ID/Secret to dedicated settings page

### DIFF
--- a/client/src/pages/AdminDiditSettings.tsx
+++ b/client/src/pages/AdminDiditSettings.tsx
@@ -27,7 +27,7 @@ export default function AdminDiditSettings() {
   const [settingsData, setSettingsData] = useState<Record<string, string>>({});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({
     didit_api_key: false,
-    // Add other secret keys if any are moved here, e.g. didit_client_secret
+    didit_client_secret: false, // Added didit_client_secret
   });
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -168,7 +168,45 @@ export default function AdminDiditSettings() {
                     </Button>
                   </div>
                 </div>
-                 {/* Client ID and Secret can be added here if they become part of this page */}
+                {/* New row for Client ID and Client Secret */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
+                  <div>
+                    <Label htmlFor="didit_client_id">Didit Client ID</Label>
+                    <Input
+                      id="didit_client_id"
+                      placeholder="your-didit-client-id"
+                      value={getSettingValue('didit_client_id')}
+                      onChange={(e) => setSettingsData(prev => ({ ...prev, didit_client_id: e.target.value }))}
+                      onBlur={(e) => handleUpdateSetting('didit_client_id', e.target.value)}
+                    />
+                    <p className="text-sm text-muted-foreground pt-1">
+                      Optional. Used for OAuth flows if applicable.
+                    </p>
+                  </div>
+                  <div>
+                    <Label htmlFor="didit_client_secret">Didit Client Secret</Label>
+                    <div className="flex items-center space-x-2">
+                      <Input
+                        id="didit_client_secret"
+                        placeholder="your-didit-client-secret"
+                        type={showSecrets['didit_client_secret'] ? 'text' : 'password'}
+                        value={getSettingValue('didit_client_secret')}
+                        onChange={(e) => setSettingsData(prev => ({ ...prev, didit_client_secret: e.target.value }))}
+                        onBlur={(e) => handleUpdateSetting('didit_client_secret', e.target.value)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleShowSecret('didit_client_secret')}
+                      >
+                        {showSecrets['didit_client_secret'] ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </Button>
+                    </div>
+                     <p className="text-sm text-muted-foreground pt-1">
+                      Optional. Used for OAuth flows if applicable. Keep this secret.
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/server/lib/admin-settings-service.ts
+++ b/server/lib/admin-settings-service.ts
@@ -55,6 +55,8 @@ export class AdminSettingsService {
       { key: 'didit_aml_sensitivity', value: 'medium' },
       { key: 'didit_age_estimation_enabled', value: 'false' },
       { key: 'didit_proof_of_address_enabled', value: 'false' },
+      { key: 'didit_client_id', value: '' },
+      { key: 'didit_client_secret', value: '' },
       { key: 'didit_webhook_url', value: '' },
       { key: 'didit_manual_override', value: 'false' },
       { key: 'min_security_level', value: '3' },


### PR DESCRIPTION
This commit adds input fields for Didit Client ID and Client Secret to the dedicated `AdminDiditSettings.tsx` page and ensures backend support for storing these settings. This addresses your feedback to consolidate all Didit related credentials in one location.

Key Changes:

1.  **UI Update (`client/src/pages/AdminDiditSettings.tsx`):**
    *   Added input fields for "Didit Client ID" and "Didit Client Secret" to the "API Credentials" section.
    *   The "Didit Client Secret" field includes show/hide functionality.
    *   These new fields are integrated with the existing mechanisms for fetching and saving settings on this page.

2.  **Backend Settings Definition (`server/lib/admin-settings-service.ts`):**
    *   Added `didit_client_id` and `didit_client_secret` to the `defaultSettings` array. This allows these values to be initialized, stored in the database, and managed via the `/api/settings` endpoint.

While the application's `kyc-service.ts` currently uses an API Key (Bearer token) for Didit API authentication, these Client ID/Secret fields are now available for configuration by administrators, potentially for other Didit API interactions or future OAuth integration.